### PR TITLE
Vite 2.7 plugin api compatibility

### DIFF
--- a/src/rollup-plugin.js
+++ b/src/rollup-plugin.js
@@ -27,7 +27,8 @@ export default function svelteFluentPlugin(options = defaultOptions) {
 			}
 		},
 
-		async resolveId(importee, importer, customOptions, ssr = options.ssr) {
+		async resolveId(importee, importer, opts, _ssr) {
+			const ssr = _ssr === true || opts.ssr;
 			if (ssr && importee === '@nubolab-ffwd/svelte-fluent') {
 				if (!resolvedSvelteFluentSSR) {
 					resolvedSvelteFluentSSR = this.resolve('@nubolab-ffwd/svelte-fluent/src/ssr', importer, {


### PR DESCRIPTION
Adds backwards compatible handling of the plugin API changes from
Vite 2.7 (https://github.com/vitejs/vite/pull/5253)